### PR TITLE
Unload model stop background

### DIFF
--- a/controllers/llamaCPP.cc
+++ b/controllers/llamaCPP.cc
@@ -295,7 +295,6 @@ void llamaCPP::backgroundTask() {
   while (model_loaded) {
     // model_loaded =
     llama.update_slots();
-    LOG_INFO << "Background state refresh!";
   }
   LOG_INFO << "Background task stopped!";
   return;

--- a/controllers/llamaCPP.h
+++ b/controllers/llamaCPP.h
@@ -2124,6 +2124,8 @@ public:
   METHOD_ADD(llamaCPP::chatCompletion, "chat_completion", Post);
   METHOD_ADD(llamaCPP::embedding, "embedding", Post);
   METHOD_ADD(llamaCPP::loadModel, "loadmodel", Post);
+  METHOD_ADD(llamaCPP::unloadModel, "unloadmodel", Get);
+
   // PATH_ADD("/llama/chat_completion", Post);
   METHOD_LIST_END
   void chatCompletion(const HttpRequestPtr &req,
@@ -2132,13 +2134,17 @@ public:
                  std::function<void(const HttpResponsePtr &)> &&callback);
   void loadModel(const HttpRequestPtr &req,
                  std::function<void(const HttpResponsePtr &)> &&callback);
+  void unloadModel(const HttpRequestPtr &req,
+                   std::function<void(const HttpResponsePtr &)> &&callback);
   void warmupModel();
 
   void backgroundTask();
 
+  void stopBackgroundTask();
+
 private:
   llama_server_context llama;
-  bool model_loaded = false;
+  std::atomic<bool> model_loaded = false;
   size_t sent_count = 0;
   size_t sent_token_probs_index = 0;
   std::thread backgroundThread;


### PR DESCRIPTION
credit to https://github.com/janhq/nitro/pull/97 for the unloading some changes i made.
- We will not implement a seperate function for the unload due to the fact that i might need to sync upstream from llama cpp very regularly, so direct implementation inside the background stop function will show me error everytime sync upstream
- Add stop background process 
- Background process dependent entirely on the model_load value