### PR TITLE
feat(embedding): Add input as vector for /embeddings

### DIFF
--- a/controllers/llamaCPP.cc
+++ b/controllers/llamaCPP.cc
@@ -21,13 +21,8 @@ std::shared_ptr<inferenceState> create_inference_state(llamaCPP *instance) {
 
 // --------------------------------------------
 
-std::string create_embedding_payload(const std::vector<float> &embedding,
+Json::Value create_embedding_payload(const std::vector<float> &embedding,
                                      int prompt_tokens) {
-  Json::Value root;
-
-  root["object"] = "list";
-
-  Json::Value dataArray(Json::arrayValue);
   Json::Value dataItem;
 
   dataItem["object"] = "embedding";
@@ -39,20 +34,7 @@ std::string create_embedding_payload(const std::vector<float> &embedding,
   dataItem["embedding"] = embeddingArray;
   dataItem["index"] = 0;
 
-  dataArray.append(dataItem);
-  root["data"] = dataArray;
-
-  root["model"] = "_";
-
-  Json::Value usage;
-  usage["prompt_tokens"] = prompt_tokens;
-  usage["total_tokens"] = prompt_tokens; // Assuming total tokens equals prompt
-                                         // tokens in this context
-  root["usage"] = usage;
-
-  Json::StreamWriterBuilder writer;
-  writer["indentation"] = ""; // Compact output
-  return Json::writeString(writer, root);
+  return dataItem;
 }
 
 std::string create_full_return_json(const std::string &id,
@@ -406,31 +388,42 @@ void llamaCPP::embedding(
     std::function<void(const HttpResponsePtr &)> &&callback) {
   const auto &jsonBody = req->getJsonObject();
 
-  json prompt;
-  if (jsonBody->isMember("input") != 0) {
-    if ((*jsonBody)["input"].isString()) {
-      prompt = (*jsonBody)["input"].asString();
-    } else if ((*jsonBody)["input"].isArray()) {
-      const auto &inputArray = (*jsonBody)["input"];
-      std::vector<std::string> inputStrings;
-      for (const auto &input : inputArray) {
-        if (input.isString()) {
-          inputStrings.push_back(input.asString());
+  Json::Value responseData(Json::arrayValue);
+
+  if (jsonBody->isMember("input")) {
+    const Json::Value &input = (*jsonBody)["input"];
+    if (input.isString()) {
+      // Process the single string input
+      const int task_id = llama.request_completion(
+          {{"prompt", input.asString()}, {"n_predict", 0}}, false, true, -1);
+      task_result result = llama.next_result(task_id);
+      std::vector<float> embedding_result = result.result_json["embedding"];
+      responseData.append(create_embedding_payload(embedding_result, 0));
+    } else if (input.isArray()) {
+      // Process each element in the array input
+      for (const auto &elem : input) {
+        if (elem.isString()) {
+          const int task_id = llama.request_completion(
+              {{"prompt", elem.asString()}, {"n_predict", 0}}, false, true, -1);
+          task_result result = llama.next_result(task_id);
+          std::vector<float> embedding_result = result.result_json["embedding"];
+          responseData.append(create_embedding_payload(embedding_result, 0));
         }
       }
-      prompt = inputStrings;
     }
-  } else {
-    prompt = "";
   }
 
-  const int task_id = llama.request_completion(
-      {{"prompt", prompt}, {"n_predict", 0}}, false, true, -1);
-  task_result result = llama.next_result(task_id);
-  std::vector<float> embedding_result = result.result_json["embedding"];
   auto resp = nitro_utils::nitroHttpResponse();
-  std::string embedding_resp = create_embedding_payload(embedding_result, 0);
-  resp->setBody(embedding_resp);
+  Json::Value root;
+  root["data"] = responseData;
+  root["model"] = "_";
+  root["object"] = "list";
+  Json::Value usage;
+  usage["prompt_tokens"] = 0;
+  usage["total_tokens"] = 0;
+  root["usage"] = usage;
+
+  resp->setBody(Json::writeString(Json::StreamWriterBuilder(), root));
   resp->setContentTypeString("application/json");
   callback(resp);
   return;


### PR DESCRIPTION
Fixes for https://github.com/janhq/nitro/issues/371

- Load model
```
curl --location 'http://127.0.0.1:3928/inferences/llamacpp/loadmodel' \
--header 'Content-Type: application/json' \
--data '{
   "llama_model_path": "/Users/hiro/Downloads/ggml-model-q4_k.gguf",
   "ctx_len": 2048,
   "ngl": 100,
   "cont_batching": false,
   "embedding": true,
   "system_prompt": "",
   "user_prompt": "\n### Instruction:\n",
   "ai_prompt": "\n### Response:\n"
 }'
```
- Embedding with input as string
```
curl --location 'http://localhost:3928/v1/embeddings' \
--header 'Content-Type: application/json' \
--header 'Accept: text/event-stream' \
--header 'Access-Control-Allow-Origin: *' \
--data '{
    "input": "Hello",
    "model": "embedding",
    "encoding_format": "float"
}'
```
- Embedding with input as vector
```
curl --location 'http://localhost:3928/v1/embeddings' \
--header 'Content-Type: application/json' \
--header 'Accept: text/event-stream' \
--header 'Access-Control-Allow-Origin: *' \
--data '{
    "input": ["Hello", "Nam", "here"],
    "model": "embedding",
    "encoding_format": "float"
}'
```