### PR TITLE
fix: CI - use hosted mac m1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -321,7 +321,7 @@ jobs:
           asset_content_type: application/gzip
 
   macOS-silicon-build:
-    runs-on: mac-silicon
+    runs-on: macos-14
     needs: [create-draft-release, set-nitro-version]
     if: always() && (needs.create-draft-release.result == 'success' || needs.create-draft-release.result == 'skipped') && needs.set-nitro-version.result == 'success'
     permissions:


### PR DESCRIPTION
Use `macos-14` for `mac-sillicon` build

Reference: 
- https://github.com/janhq/nitro/pull/new/fix/ci_hosted_mac_m1