### PR TITLE
refactor: simplify state with queued system

### DIFF
--- a/controllers/llamaCPP.h
+++ b/controllers/llamaCPP.h
@@ -26,6 +26,7 @@
 
 #include "common/base.h"
 #include "utils/json.hpp"
+#include <trantor/utils/ConcurrentTaskQueue.h>
 
 // auto generated files (update with ./deps.sh)
 
@@ -2562,9 +2563,12 @@ private:
   bool caching_enabled;
   std::atomic<int> no_of_chats = 0;
   int clean_cache_threshold;
-  std::atomic<bool> single_queue_is_busy; // This value only used under the
-                                          // condition n_parallel is 1
   std::string grammar_file_content;
+
+  /**
+   * Queue to handle the inference tasks
+   */
+  trantor::ConcurrentTaskQueue *queue;
 
   bool loadModelImpl(std::shared_ptr<Json::Value> jsonBody);
   void inferenceImpl(std::shared_ptr<Json::Value> jsonBody,


### PR DESCRIPTION
## Description
- Deprecate shared single_queue_busy state & SerialTaskQueue since it would not work with cont_batching = true and n_parallel > 1.
- Deprecate instance's is_stopped state, better using inferenceStatus enum.
- Introduce ConcurrentTaskQueue to handle tasks with the workers number = n_parallel.
- No complicated state handling, put into the queue and it just work (inference & embedding).

Test results
- n_parallel = 1 & cont_batching = false
  ```
  |        T1          |       T2           |       T3          |       T4          |
  |--------------------|--------------------|-------------------|-------------------|
  | Send chat comp.    | Send chat          | A1 completed      | A2 completed      |
  | request A1         | comp. request A2   | A2 started        |                   |
  |                    |                    |                   |                   |
  |                    |                    |                   |                   |
  ```
- n_parallel = 2 & cont_batching = true
  ```
  |      T1      |      T2      |       T3       |       T4       |                T5               |
  |--------------|--------------|----------------|----------------|--------------------------------|
  | Send chat    | Send chat    | A1 & A2 are    | Send chat      | A1 & A2 are                    |         
  | completion   | completion   | running        | completion     | completed                      |                            
  | request A1   | request A2   |                | request A3     | A3 started running             |                 
  ```