### PR TITLE
fix: nitro sends incorrect content type header

### DIFF
--- a/utils/nitro_utils.h
+++ b/utils/nitro_utils.h
@@ -239,8 +239,8 @@ inline drogon::HttpResponsePtr nitroHttpJsonResponse(const Json::Value &data) {
 inline drogon::HttpResponsePtr nitroStreamResponse(
     const std::function<std::size_t(char *, std::size_t)> &callback,
     const std::string &attachmentFileName = "") {
-  auto resp =
-      drogon::HttpResponse::newStreamResponse(callback, attachmentFileName);
+  auto resp = drogon::HttpResponse::newStreamResponse(
+      callback, attachmentFileName, drogon::CT_NONE, "text/event-stream");
 #ifdef ALLOW_ALL_CORS
   LOG_INFO << "Respond for all cors!";
   resp->addHeader("Access-Control-Allow-Origin", "*");


### PR DESCRIPTION
Current response content-type header: text/plain. Postman shows a blank page until the response is fully streamed, which may break some clients.

<img width="380" alt="Screenshot 2024-02-16 at 21 12 04" src="https://github.com/janhq/nitro/assets/133622055/6ef395be-1e96-4b75-ba80-62bf42f5366f">
<img width="380" alt="Screenshot 2024-02-16 at 21 12 08" src="https://github.com/janhq/nitro/assets/133622055/f8ce572b-1bd6-4d93-8109-e508ab4c8b25">



Fixed: Stream yields results in real-time.

<img width="380" alt="Screenshot 2024-02-16 at 21 11 30" src="https://github.com/janhq/nitro/assets/133622055/97b0a4dc-ad2f-4c31-97bb-9d4ae1a7456a">
<img width="380" alt="Screenshot 2024-02-16 at 21 11 33" src="https://github.com/janhq/nitro/assets/133622055/6874cd4a-b5d0-45b1-ac72-b938a142f78d">
