### PR TITLE
feat: Add Nitro support for different CPU instructions and architecture

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -136,8 +136,8 @@ jobs:
             defines: "-DLLAMA_NATIVE=OFF"
           - build: "amd64-avx"
             defines: "-DLLAMA_AVX2=OFF -DLLAMA_NATIVE=OFF"
-          # - build: "amd64-avx512"
-          #   defines: "-DLLAMA_AVX512=ON -DLLAMA_NATIVE=OFF"
+          - build: "amd64-avx512"
+            defines: "-DLLAMA_AVX512=ON -DLLAMA_NATIVE=OFF"
           - build: "amd64-vulkan"
             defines: "-DLLAMA_VULKAN=ON -DLLAMA_NATIVE=OFF"
           # - build: "arm64"
@@ -184,7 +184,7 @@ jobs:
 
       - name: Run e2e testing - LLama.CPP
         shell: bash
-        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' }}
+        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' && matrix.build != 'amd64-avx512' }}
         run: |
           # run e2e testing
           cd nitro
@@ -193,7 +193,7 @@ jobs:
 
       - name: Run e2e testing - Whisper.CPP
         shell: bash
-        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' }}
+        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' && matrix.build != 'amd64-avx512' }}
         run: |
           # run e2e testing
           cd nitro
@@ -496,22 +496,9 @@ jobs:
           7z a -ttar temp.tar .\build\Release\*
           7z a -tgzip nitro.tar.gz temp.tar
 
-      # - name: Check AVX512F support
-      #   id: check_avx512f
-      #   if: ${{ matrix.build == 'avx512' }}
-      #   continue-on-error: true
-      #   run: |
-      #     cd build
-      #     $vcdir = $(vswhere -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath)
-      #     $msvc = $(join-path $vcdir $('VC\Tools\MSVC\'+$(gc -raw $(join-path $vcdir 'VC\Auxiliary\Build\Microsoft.VCToolsVersion.default.txt')).Trim()))
-      #     $cl =  $(join-path $msvc 'bin\Hostx64\x64\cl.exe')
-      #     echo 'int main(void){unsigned int a[4];__cpuid(a,7);return !(a[1]&65536);}' >> avx512f.c
-      #     & $cl /O2 /GS- /kernel avx512f.c /link /nodefaultlib /entry:main
-      #     .\avx512f.exe && echo "AVX512F: YES" && ( echo HAS_AVX512F=1 >> $env:GITHUB_ENV ) || echo "AVX512F: NO"
-
       - name: Run e2e testing - Llama.cpp
         shell: cmd
-        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' }}
+        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' && matrix.build != 'amd64-avx512' }}
         run: |
           cd build\Release
           ..\..\.github\scripts\e2e-test-llama-windows.bat nitro.exe ${{ env.LLM_MODEL_URL }}
@@ -519,7 +506,7 @@ jobs:
 
       - name: Run e2e testing - Whisper.cpp
         shell: cmd
-        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' }}
+        if: ${{ matrix.build != 'arm64' && matrix.build != 'amd64-vulkan' && matrix.build != 'amd64-avx512' }}
         run: |
           cd build\Release
           ..\..\.github\scripts\e2e-test-whisper-windows.bat nitro.exe ${{ env.WHISPER_MODEL_URL }}


### PR DESCRIPTION
Fix for https://github.com/janhq/nitro/issues/463

- [x] Rename `amd64` to `amd64-avx2` (as default option)
- [x] Add `amd64-avx` (with/ without CUDA)
- [x] Add `amd64-avx512` (with/ without CUDA)
- [x] Refactor `amd64-vulkan` in matrix strategy