### PR TITLE
add 'set -e' to ensure script termination on error

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/bash -e
 
 # Check for root privileges
 if [ "$(id -u)" != "0" ]; then


### PR DESCRIPTION
This change modifies the script's shebang to include the '-e' option, ensuring that the script exits immediately if a command exits with a non-zero status. This enhancement aims to improve the robustness and reliability of the installation process by preventing the script from continuing execution in the event of an error, which could lead to incomplete or incorrect installations.