### PR TITLE
Prompt user for AVX version in **install.bat**

### DIFF
--- a/install.bat
+++ b/install.bat
@@ -7,10 +7,18 @@ if exist "%APPDATA%\nitro" (
     rmdir /S /Q "%APPDATA%\nitro"
 )
 
-
 :: Parse arguments
 set "VERSION=latest"
 set "GPU=false"
+set "AVX=-avx2"
+
+echo Please enter the AVX version you want (avx, avx2, avx512) or leave blank for default (avx2):
+set /p USER_AVX=
+
+if not "%USER_AVX%"=="" (
+    set "AVX=-%USER_AVX%"
+)
+
 :arg_loop
 if "%~1"=="" goto arg_loop_end
 if "%~1"=="--gpu" (
@@ -37,7 +45,7 @@ if "%VERSION%"=="latest" (
 )
 
 :: Construct the download URL
-set "URL=https://github.com/janhq/nitro/releases/download/v%VERSION%/nitro-%VERSION%-win-amd64"
+set "URL=https://github.com/janhq/nitro/releases/download/v%VERSION%/nitro-%VERSION%-win-amd64%AVX%"
 if "%GPU%"=="true" (
     :: If --gpu option is provided, append -cuda to the URL
     set "URL=%URL%-cuda"

--- a/install.bat
+++ b/install.bat
@@ -12,7 +12,7 @@ set "VERSION=latest"
 set "GPU=false"
 set "AVX=-avx2"
 
-echo Please enter the AVX version you want (avx, avx2, avx512) or leave blank for default (avx2):
+echo Please specify the desired AVX version (avx, avx2, avx512), or leave it blank to use the default version (avx2):
 set /p USER_AVX=
 
 if not "%USER_AVX%"=="" (


### PR DESCRIPTION
This pull request addresses an issue from pull request #464 , which caused Nitro software installation failures due to a missing AVX version specification.

I've updated the script to prompt the user for an AVX version (avx, avx2, avx512) during the installation, defaulting to AVX2 if no input is provided.

Feel free to contact me if you have any issues 😄 