### PR TITLE
fix: app hangs if we unload model during stream completion 

### DIFF
--- a/.github/scripts/e2e-test-llama-linux-and-mac.sh
+++ b/.github/scripts/e2e-test-llama-linux-and-mac.sh
@@ -65,14 +65,12 @@ fi
 response2=$(
     curl --connect-timeout 60 -o /tmp/completion-res.log -s -w "%{http_code}" --location "http://127.0.0.1:$PORT/v1/chat/completions" \
         --header 'Content-Type: application/json' \
-        --header 'Accept: text/event-stream' \
-        --header 'Access-Control-Allow-Origin: *' \
         --data '{
         "messages": [
             {"content": "Hello there", "role": "assistant"},
             {"content": "Write a long and sad story for me", "role": "user"}
         ],
-        "stream": true,
+        "stream": false,
         "model": "gpt-3.5-turbo",
         "max_tokens": 50,
         "stop": ["hello"],

--- a/.github/scripts/e2e-test-llama-linux-and-mac.sh
+++ b/.github/scripts/e2e-test-llama-linux-and-mac.sh
@@ -65,12 +65,14 @@ fi
 response2=$(
     curl --connect-timeout 60 -o /tmp/completion-res.log -s -w "%{http_code}" --location "http://127.0.0.1:$PORT/v1/chat/completions" \
         --header 'Content-Type: application/json' \
+        --header 'Accept: text/event-stream' \
+        --header 'Access-Control-Allow-Origin: *' \
         --data '{
         "messages": [
             {"content": "Hello there", "role": "assistant"},
             {"content": "Write a long and sad story for me", "role": "user"}
         ],
-        "stream": false,
+        "stream": true,
         "model": "gpt-3.5-turbo",
         "max_tokens": 50,
         "stop": ["hello"],

--- a/controllers/llamaCPP.cc
+++ b/controllers/llamaCPP.cc
@@ -190,8 +190,7 @@ void llamaCPP::InferenceImpl(
   if (llama.model_type == ModelType::EMBEDDING) {
     LOG_WARN << "Not support completion for embedding model";
     Json::Value jsonResp;
-    jsonResp["message"] =
-        "Not support completion for embedding model";
+    jsonResp["message"] = "Not support completion for embedding model";
     auto resp = nitro_utils::nitroHttpJsonResponse(jsonResp);
     resp->setStatusCode(drogon::k400BadRequest);
     callback(resp);
@@ -429,7 +428,8 @@ void llamaCPP::InferenceImpl(
 
       // Since this is an async task, we will wait for the task to be
       // completed
-      while (state->inference_status != FINISHED && retries < 10) {
+      while (state->inference_status != FINISHED && retries < 10 &&
+             state->instance->llama.model_loaded_external) {
         // Should wait chunked_content_provider lambda to be called within
         // 3s
         if (state->inference_status == PENDING) {
@@ -748,9 +748,10 @@ void llamaCPP::StopBackgroundTask() {
   if (llama.model_loaded_external) {
     llama.model_loaded_external = false;
     llama.condition_tasks.notify_one();
-    LOG_INFO << "Background task stopped! ";
+    LOG_INFO << "Stopping background task! ";
     if (backgroundThread.joinable()) {
       backgroundThread.join();
     }
+    LOG_INFO << "Background task stopped! ";
   }
 }


### PR DESCRIPTION
Currently e2e scripts can be hang because we unload model when still receiving the stream. Change to non-stream to temporary fix issue.