### PR TITLE
Fix: Include algorithm header file to fix build on other distros

### DIFF
--- a/engine/common/download_task_queue.h
+++ b/engine/common/download_task_queue.h
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -6,7 +7,6 @@
 #include <string>
 #include <unordered_map>
 #include "common/download_task.h"
-#include <algorithm>
 
 class DownloadTaskQueue {
  private:

--- a/engine/common/download_task_queue.h
+++ b/engine/common/download_task_queue.h
@@ -6,6 +6,7 @@
 #include <string>
 #include <unordered_map>
 #include "common/download_task.h"
+#include <algorithm>
 
 class DownloadTaskQueue {
  private:

--- a/engine/repositories/assistant_fs_repository.cc
+++ b/engine/repositories/assistant_fs_repository.cc
@@ -1,10 +1,10 @@
 #include "assistant_fs_repository.h"
 #include <json/reader.h>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include <mutex>
 #include "utils/result.hpp"
-#include <algorithm>
 
 cpp::result<std::vector<OpenAi::Assistant>, std::string>
 AssistantFsRepository::ListAssistants(uint8_t limit, const std::string& order,

--- a/engine/repositories/assistant_fs_repository.cc
+++ b/engine/repositories/assistant_fs_repository.cc
@@ -4,6 +4,7 @@
 #include <fstream>
 #include <mutex>
 #include "utils/result.hpp"
+#include <algorithm>
 
 cpp::result<std::vector<OpenAi::Assistant>, std::string>
 AssistantFsRepository::ListAssistants(uint8_t limit, const std::string& order,

--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -5,6 +5,7 @@
 #include "database/file.h"
 #include "utils/logging_utils.h"
 #include "utils/result.hpp"
+#include <algorithm>
 
 std::filesystem::path FileFsRepository::GetFilePath() const {
   return data_folder_path_ / kFileContainerFolderName;

--- a/engine/repositories/file_fs_repository.cc
+++ b/engine/repositories/file_fs_repository.cc
@@ -1,11 +1,11 @@
 #include "file_fs_repository.h"
 #include <json/reader.h>
+#include <algorithm>
 #include <filesystem>
 #include <fstream>
 #include "database/file.h"
 #include "utils/logging_utils.h"
 #include "utils/result.hpp"
-#include <algorithm>
 
 std::filesystem::path FileFsRepository::GetFilePath() const {
   return data_folder_path_ / kFileContainerFolderName;

--- a/engine/repositories/thread_fs_repository.cc
+++ b/engine/repositories/thread_fs_repository.cc
@@ -3,6 +3,7 @@
 #include <mutex>
 #include "common/assistant.h"
 #include "utils/result.hpp"
+#include <algorithm>
 
 cpp::result<std::vector<OpenAi::Thread>, std::string>
 ThreadFsRepository::ListThreads(uint8_t limit, const std::string& order,

--- a/engine/repositories/thread_fs_repository.cc
+++ b/engine/repositories/thread_fs_repository.cc
@@ -1,9 +1,9 @@
 #include "thread_fs_repository.h"
+#include <algorithm>
 #include <fstream>
 #include <mutex>
 #include "common/assistant.h"
 #include "utils/result.hpp"
-#include <algorithm>
 
 cpp::result<std::vector<OpenAi::Thread>, std::string>
 ThreadFsRepository::ListThreads(uint8_t limit, const std::string& order,


### PR DESCRIPTION
## Describe Your Changes
Build currently breaks on distributions other than Ubuntu because of a missing header file.
This patch attempts to fix that.