### PR TITLE
chore: download cmake version 3.22.6

### DIFF
--- a/.github/workflows/cortex-cpp-quality-gate.yml
+++ b/.github/workflows/cortex-cpp-quality-gate.yml
@@ -8,6 +8,7 @@ on:
   schedule:
     - cron: '0 22 * * *'
 
+
 env:
   LLM_MODEL_URL: https://delta.jan.ai/tinyllama-1.1b-chat-v0.3.Q2_K.gguf
   EMBEDDING_MODEL_URL: https://catalog.jan.ai/dist/models/embeds/nomic-embed-text-v1.5.f16.gguf

--- a/.github/workflows/cortex-cpp-quality-gate.yml
+++ b/.github/workflows/cortex-cpp-quality-gate.yml
@@ -8,7 +8,6 @@ on:
   schedule:
     - cron: '0 22 * * *'
 
-
 env:
   LLM_MODEL_URL: https://delta.jan.ai/tinyllama-1.1b-chat-v0.3.Q2_K.gguf
   EMBEDDING_MODEL_URL: https://catalog.jan.ai/dist/models/embeds/nomic-embed-text-v1.5.f16.gguf
@@ -151,6 +150,7 @@ jobs:
         run: |
           cd engine
           mkdir -p ~/.config/cortexcpp/
+          mkdir -p ~/.local/share/cortexcpp/
           echo "huggingFaceToken: ${{ secrets.HUGGINGFACE_TOKEN_READ }}" > ~/.config/cortexcpp/.cortexrc
           echo "gitHubToken: ${{ secrets.PAT_SERVICE_ACCOUNT }}" >> ~/.config/cortexcpp/.cortexrc
           # ./build/cortex
@@ -178,6 +178,7 @@ jobs:
         run: |
           cd engine
           mkdir -p ~/.config/cortexcpp/
+          mkdir -p ~/.local/share/cortexcpp/
           echo "apiServerPort: 3928" > ~/.config/cortexcpp/.cortexrc
           echo "huggingFaceToken: ${{ secrets.HUGGINGFACE_TOKEN_READ }}" >> ~/.config/cortexcpp/.cortexrc
           echo "gitHubToken: ${{ secrets.PAT_SERVICE_ACCOUNT }}" >> ~/.config/cortexcpp/.cortexrc
@@ -457,6 +458,7 @@ jobs:
         run: |
           cd engine
           mkdir -p ~/.config/cortexcpp/
+          mkdir -p ~/.local/share/cortexcpp/
           echo "gitHubToken: ${{ secrets.GITHUB_TOKEN }}" > ~/.config/cortexcpp/.cortexrc
           # ./build/cortex
           cat ~/.config/cortexcpp/.cortexrc
@@ -482,6 +484,7 @@ jobs:
         run: |
           cd engine
           mkdir -p ~/.config/cortexcpp/
+          mkdir -p ~/.local/share/cortexcpp/
           echo "apiServerPort: 3928" > ~/.config/cortexcpp/.cortexrc
           echo "gitHubToken: ${{ secrets.GITHUB_TOKEN }}" > ~/.config/cortexcpp/.cortexrc
           # ./build/cortex

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,10 +37,20 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     ninja-build \
     pkg-config \
     python3-pip \
-    openssl && \
+    openssl \
+    libssl-dev && \
     pip3 install awscli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and install CMake 3.22.6
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6.tar.gz -q -O /tmp/cmake.tar.gz && \
+    tar -xzf /tmp/cmake.tar.gz -C /tmp && \
+    cd /tmp/cmake-3.22.6 && \
+    ./bootstrap && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/cmake.tar.gz /tmp/cmake-3.22.6
 
 ARG CORTEX_CPP_VERSION=latest
 ARG CMAKE_EXTRA_FLAGS=""

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -24,7 +24,6 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    cmake \
     make \
     git \
     uuid-dev \

--- a/docker/Dockerfile.cache
+++ b/docker/Dockerfile.cache
@@ -37,10 +37,20 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     ninja-build \
     pkg-config \
     python3-pip \
-    openssl && \
+    openssl \
+    libssl-dev && \
     pip3 install awscli && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*
+
+# Download and install CMake 3.22.6
+RUN wget https://github.com/Kitware/CMake/releases/download/v3.22.6/cmake-3.22.6.tar.gz -q -O /tmp/cmake.tar.gz && \
+    tar -xzf /tmp/cmake.tar.gz -C /tmp && \
+    cd /tmp/cmake-3.22.6 && \
+    ./bootstrap && \
+    make -j$(nproc) && \
+    make install && \
+    rm -rf /tmp/cmake.tar.gz /tmp/cmake-3.22.6
 
 ARG CORTEX_CPP_VERSION=latest
 ARG CMAKE_EXTRA_FLAGS=""

--- a/docker/Dockerfile.cache
+++ b/docker/Dockerfile.cache
@@ -24,7 +24,6 @@ RUN wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/nul
     apt-add-repository "deb https://apt.kitware.com/ubuntu/ $(lsb_release -cs) main" && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
-    cmake \
     make \
     git \
     uuid-dev \


### PR DESCRIPTION
This pull request includes updates to the Dockerfiles to add necessary dependencies and install a specific version of CMake. The changes ensure that the required libraries are available and that CMake 3.22.6 is installed in the Docker images.

Dependencies and installation updates:

* [`docker/Dockerfile`](diffhunk://#diff-f34da55ca08f1a30591d8b0b3e885bcc678537b2a9a4aadea4f190806b374ddcL40-R54): Added `libssl-dev` to the list of packages and included steps to download, extract, and install CMake 3.22.6.
* [`docker/Dockerfile.cache`](diffhunk://#diff-1cef051193b05901a7b8f2b8e94f05267e5a29bd93c2e22f05da1e6d16b8c2ffL40-R54): Added `libssl-dev` to the list of packages and included steps to download, extract, and install CMake 3.22.6.