### PR TITLE
fix: handle more parameters

### DIFF
--- a/engine/extensions/local-engine/local_engine.cc
+++ b/engine/extensions/local-engine/local_engine.cc
@@ -20,7 +20,7 @@ const std::unordered_set<std::string> kIgnoredParams = {
     "user_prompt",  "min_keep",        "mirostat",   "mirostat_eta",
     "mirostat_tau", "text_model",      "version",    "n_probs",
     "object",       "penalize_nl",     "precision",  "size",
-    "stop",         "tfs_z",           "typ_p"};
+    "stop",         "tfs_z",           "typ_p",      "caching_enabled"};
 
 const std::unordered_map<std::string, std::string> kParamsMap = {
     {"cpu_threads", "--threads"},
@@ -65,6 +65,19 @@ std::vector<std::string> ConvertJsonToParamsVector(const Json::Value& root) {
     } else if (member == "model_type") {
       if (root[member].asString() == "embedding") {
         res.push_back("--embedding");
+      }
+      continue;
+    } else if (member == "cache_type") {
+      if (!root[member].isNull()) {
+        res.push_back("-ctk");
+        res.push_back(root[member].asString());
+        res.push_back("-ctv");
+        res.push_back(root[member].asString());
+      }
+      continue;
+    } else if (member == "use_mmap") {
+      if (!root[member].asBool()) {
+        res.push_back("--no-mmap");
       }
       continue;
     }

--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -772,7 +772,13 @@ EngineService::GetInstalledEngineVariants(const std::string& engine) const {
         // try to find version.txt
         auto version_txt_path = version_entry.path() / "version.txt";
         if (!std::filesystem::exists(version_txt_path)) {
-          continue;
+          // create new one
+          std::ofstream meta(version_txt_path, std::ios::out);
+          meta << "name: " << entry.path().filename() << std::endl;
+          meta << "version: " << version_entry.path().filename() << std::endl;
+          meta.close();
+          CTL_INF("name: " << entry.path().filename().string() << ", version: "
+                           << version_entry.path().filename().string());
         }
 
         try {

--- a/engine/services/engine_service.cc
+++ b/engine/services/engine_service.cc
@@ -871,7 +871,9 @@ void EngineService::RegisterEngineLibPath() {
 
       // register deps
       std::vector<std::filesystem::path> paths{};
-      paths.push_back(cuda_path);
+      if (std::filesystem::exists(cuda_path)) {
+        paths.push_back(cuda_path);
+      }
       paths.push_back(engine_dir_path);
 
       CTL_DBG("Registering dylib for "


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces new parameters to the local engine configuration and enhances the parameter conversion functionality. The most important changes include adding the `caching_enabled` parameter to the ignored parameters list and handling new parameters `cache_type` and `use_mmap` in the JSON to parameters vector conversion.

Enhancements to parameter handling:

* [`engine/extensions/local-engine/local_engine.cc`](diffhunk://#diff-1c8763efbaf74302a6f82a208ab06fa904af048d57f79e10e75cc53aa9fb547dL23-R23): Added `caching_enabled` to the ignored parameters list (`kIgnoredParams`).
* [`engine/extensions/local-engine/local_engine.cc`](diffhunk://#diff-1c8763efbaf74302a6f82a208ab06fa904af048d57f79e10e75cc53aa9fb547dR70-R82): Updated `ConvertJsonToParamsVector` to handle `cache_type` and `use_mmap` parameters.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed