### PR TITLE
fix: correct cortex.cpp urls

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Cortex is the open-source brain for robots: vision, speech, language, tabular, a
 
 All other Linux distributions:
 ```bash
-curl -s https://raw.githubusercontent.com/menloresearch/cortex/main/engine/templates/linux/install.sh | sudo bash
+curl -s https://raw.githubusercontent.com/menloresearch/cortex.cpp/main/engine/templates/linux/install.sh | sudo bash
 ```
 
 ### Start the Server

--- a/docs/docs/installation/linux.mdx
+++ b/docs/docs/installation/linux.mdx
@@ -27,12 +27,12 @@ This instruction is for stable releases. For beta and nightly releases, please r
 
 - Network installer for all linux distros
    ```bash
-   curl -s https://raw.githubusercontent.com/menloresearch/cortex/main/engine/templates/linux/install.sh | sudo bash -s
+   curl -s https://raw.githubusercontent.com/menloresearch/cortex.cpp/main/engine/templates/linux/install.sh | sudo bash -s
    ```
 
 - Local installer for Debian-based distros
    ```bash
-   curl -s https://raw.githubusercontent.com/menloresearch/cortex/main/engine/templates/linux/install.sh | sudo bash -s -- --deb_local
+   curl -s https://raw.githubusercontent.com/menloresearch/cortex.cpp/main/engine/templates/linux/install.sh | sudo bash -s -- --deb_local
    ```
 
 - Parameters

--- a/engine/README.md
+++ b/engine/README.md
@@ -1,11 +1,11 @@
 # cortex-cpp - Embeddable AI
 <p align="center">
-  <img alt="cortex-cpplogo" src="https://raw.githubusercontent.com/menloresearch/cortex/dev/assets/cortex-banner.png">
+  <img alt="cortex-cpplogo" src="https://raw.githubusercontent.com/menloresearch/cortex.cpp/dev/assets/cortex-banner.png">
 </p>
 
 <p align="center">
   <a href="https://jan.ai/cortex">Documentation</a> - <a href="https://jan.ai/api-reference">API Reference</a> 
-  - <a href="https://github.com/menloresearch/cortex/releases">Changelog</a> - <a href="https://github.com/menloresearch/cortex/issues">Bug reports</a> - <a href="https://discord.gg/AsJ8krTT3N">Discord</a>
+  - <a href="https://github.com/menloresearch/cortex.cpp/releases">Changelog</a> - <a href="https://github.com/menloresearch/cortex.cpp/issues">Bug reports</a> - <a href="https://discord.gg/AsJ8krTT3N">Discord</a>
 </p>
 
 > ⚠️ **cortex-cpp is currently in Development**: Expect breaking changes and bugs!
@@ -41,7 +41,7 @@ Ensure that your system meets the following requirements to run Cortex:
 
 ## Quickstart
 To install Cortex CLI, follow the steps below:
-1. Download cortex-cpp here: https://github.com/menloresearch/cortex/releases
+1. Download cortex-cpp here: https://github.com/menloresearch/cortex.cpp/releases
 2. Install cortex-cpp by running the downloaded file.
 
 3. Download a Model:
@@ -121,37 +121,37 @@ Below is the available list of the model parameters you can set when loading a m
   <tr>
     <td style="text-align:center"><b>Stable (Recommended)</b></td>
     <td style="text-align:center">
-      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex.cpp/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2.tar.gz'>
         <img src='./docs/static/img/windows.png' style="height:15px; width: 15px" />
         <b>CPU</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2-cuda-12-0.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex.cpp/releases/download/v0.4.12/cortex-cpp-0.4.12-windows-amd64-avx2-cuda-12-0.tar.gz'>
         <img src='./docs/static/img/windows.png' style="height:15px; width: 15px" />
         <b>CUDA</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-amd64.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex.cpp/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-amd64.tar.gz'>
         <img src='./docs/static/img/mac.png' style="height:15px; width: 15px" />
         <b>Intel</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-arm64.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex.cpp/releases/download/v0.4.12/cortex-cpp-0.4.12-mac-arm64.tar.gz'>
         <img src='./docs/static/img/mac.png' style="height:15px; width: 15px" />
         <b>M1/M2</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-avx2.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex.cpp/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-avx2.tar.gz'>
         <img src='./docs/static/img/linux.png' style="height:15px; width: 15px" />
         <b>CPU</b>
       </a>
     </td>
     <td style="text-align:center">
-      <a href='https://github.com/menloresearch/cortex/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-cuda-12-0.tar.gz'>
+      <a href='https://github.com/menloresearch/cortex.cpp/releases/download/v0.4.12/cortex-cpp-0.4.12-linux-amd64-cuda-12-0.tar.gz'>
         <img src='./docs/static/img/linux.png' style="height:15px; width: 15px" />
         <b>CUDA</b>
       </a>
@@ -159,7 +159,7 @@ Below is the available list of the model parameters you can set when loading a m
   </tr>
 </table>
 
-> Download the latest or older versions of Cortex-cpp at the **[GitHub Releases](https://github.com/menloresearch/cortex/releases)**.
+> Download the latest or older versions of Cortex-cpp at the **[GitHub Releases](https://github.com/menloresearch/cortex.cpp/releases)**.
 
 
 ## Manual Build

--- a/engine/install.bat
+++ b/engine/install.bat
@@ -45,7 +45,7 @@ if "%VERSION%"=="latest" (
 )
 
 :: Construct the download URL
-set "URL=https://github.com/menloresearch/cortex/releases/download/v%VERSION%/cortex-cpp-%VERSION%-win-amd64%AVX%"
+set "URL=https://github.com/menloresearch/cortex.cpp/releases/download/v%VERSION%/cortex-cpp-%VERSION%-win-amd64%AVX%"
 if "%GPU%"=="true" (
     :: If --gpu option is provided, append -cuda to the URL
     set "URL=%URL%-cuda"

--- a/engine/install.sh
+++ b/engine/install.sh
@@ -139,7 +139,7 @@ fi
 
 # Construct GitHub API URL and get latest version if not specified
 if [ "$VERSION" == "latest" ]; then
-    API_URL="https://api.github.com/repos/menloresearch/cortex/releases/latest"
+    API_URL="https://api.github.com/repos/menloresearch/cortex.cpp/releases/latest"
     VERSION=$(curl -s $API_URL | jq -r ".tag_name" | sed 's/^v//')
 fi
 


### PR DESCRIPTION
This pull request includes changes to update the repository references from `cortex` to `cortex.cpp` across various documentation and installation files. The most important changes are listed below:

Updates to repository references:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L38-R38): Updated the installation command to reference the new repository `cortex.cpp`.
* [`docs/docs/installation/linux.mdx`](diffhunk://#diff-0549a597394c5dade16f880ccd7db645efeca52d3267595e1058b583174d5085L30-R35): Updated the network and local installer commands to reference `cortex.cpp`.
* [`engine/README.md`](diffhunk://#diff-78692e5a5d793b5257775d62b6fb596b7a11b3757d7a9ee0414cbe44b1ef444bL3-R8): Updated image source URLs, download links, and documentation references to use `cortex.cpp`. [[1]](diffhunk://#diff-78692e5a5d793b5257775d62b6fb596b7a11b3757d7a9ee0414cbe44b1ef444bL3-R8) [[2]](diffhunk://#diff-78692e5a5d793b5257775d62b6fb596b7a11b3757d7a9ee0414cbe44b1ef444bL44-R44) [[3]](diffhunk://#diff-78692e5a5d793b5257775d62b6fb596b7a11b3757d7a9ee0414cbe44b1ef444bL124-R162)

Changes in installation scripts:

* [`engine/install.bat`](diffhunk://#diff-4952ba7afbd6f21a56fc79569bc7108285982268255adb54a1a2be72863554cbL48-R48): Modified the download URL to reference `cortex.cpp` releases.
* [`engine/install.sh`](diffhunk://#diff-63ce061499628c8cf25e1606f7a23f645e1c37c44325240bd5c699feb42f9c1cL142-R142): Changed the GitHub API URL to fetch the latest version from `cortex.cpp` releases.