### PR TITLE
fix bug where for local models, delete only the model passed in, not …

### DIFF
--- a/engine/services/model_service.cc
+++ b/engine/services/model_service.cc
@@ -500,13 +500,10 @@ cpp::result<void, std::string> ModelService::DeleteModel(
       std::filesystem::remove(yaml_fp);
       CTL_INF("Removed: " << yaml_fp.string());
     } else {
-      // Remove yaml files
-      for (const auto& entry :
-           std::filesystem::directory_iterator(yaml_fp.parent_path())) {
-        if (entry.is_regular_file() && (entry.path().extension() == ".yml")) {
-          std::filesystem::remove(entry);
-          CTL_INF("Removed: " << entry.path().string());
-        }
+      // Is a local model - Remove only this model's yaml file
+      if (std::filesystem::exists(yaml_fp)) {
+        std::filesystem::remove(yaml_fp);
+        CTL_INF("Removed: " << yaml_fp.string());
       }
     }
 


### PR DESCRIPTION
…all local models

## Describe Your Changes
In [Jan](https://github.com/menloresearch/jan), I experienced a bug where I would import a model and all of a sudden, all of my other models were gone. I just did some digging finally and it appears that actually what was happening was that I previously deleted a local model, and that deleted all of my local models (all symbolic links). This should provide expected behavior of DeleteModel

## Fixes Issues

- I haven't created a bug, but I think this is the fix

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [?] Updated docs (for bug fixes / features)
- [na] Created issues for follow-up changes or refactoring needed