### PR TITLE
fix: do not ignore client request param

### DIFF
--- a/engine/extensions/local-engine/local_engine.cc
+++ b/engine/extensions/local-engine/local_engine.cc
@@ -23,7 +23,6 @@ const std::unordered_set<std::string> kIgnoredParams = {
     "user_prompt",  "min_keep",        "mirostat",   "mirostat_eta",
     "mirostat_tau", "text_model",      "version",    "n_probs",
     "object",       "penalize_nl",     "precision",  "size",
-    "flash_attn",
     "stop",         "tfs_z",           "typ_p",      "caching_enabled"};
 
 const std::unordered_map<std::string, std::string> kParamsMap = {


### PR DESCRIPTION
## Describe Your Changes

Should not ignore flash_attn settings from backend

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed